### PR TITLE
Replace => syntax with =

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Syntax
 
     @NT( a, b )                 -> Defines a tuple with a and b as members
     @NT( a::Int64, b::Float64 ) -> Defines a tuple with the specific arg types as members
-    @NT( a => 1, b => "hello")  -> Defines and constructs a tuple with the specifed members and values
+    @NT( a = 1, b = "hello")  -> Defines and constructs a tuple with the specifed members and values
     @NT( a, b )( 1, "hello")    -> Is equivalent to the above definition
     @NT( a::Int64 )( 2.0 )      -> Calls `convert( Int64, 2.0 )` on construction and sets `a`
     @NT( ::Int64, ::Float64 )   -> Defines a named tuple with automatic names
@@ -22,7 +22,7 @@ NamedTuples may be used anywhere you would use a regular Tuple, this includes me
     function foo( y )
         a = 1
         x = 3
-        return  @NT( a => 1, b => "world", c => "hello", d=>a/x, y => a/y  )
+        return  @NT( a = 1, b = "world", c = "hello", d=a/x, y = a/y  )
     end
     function bar( nt::@NT( a::Int64, c::ASCIIString ))
         return repeat( nt.c, nt.a )
@@ -31,37 +31,37 @@ NamedTuples may be used anywhere you would use a regular Tuple, this includes me
     end
 
     Test.foo( 1 ) # Returns a NamedTuple of 5 elements
-    Test.bar( @NT( a=> 2, c=>"hello")) # Returns `hellohello`
+    Test.bar( @NT( a= 2, c="hello")) # Returns `hellohello`
 
 
 There is at most one instance of a NamedTuple type with a given set of Members and Types, hence
 
-    typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a => 1, b => 2.0 ))
+    typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
 
 NamedTuple definitions are shared across all modules. The underlying immutable types are constructed at first use.
 
 NamedTuples support iteration and indexing, and behave as immutable associative containers.
 
-    @NT( a => 1 ).a == 1
-    @NT( a => 1 )[1] == 1
-    @NT( a => 1 )[:a] == 1
-    length( @NT( a => 1)) == 1
-    length( @NT( a => 1, b => 2.0)) == 2
-    first( @NT( a => 1, b => 2.0 )) ==  1
-    last( @NT( a => 1, b => 2.0 )) == 2.0
-    for( (k,v) in @NT( a => 1, b => 1 ))
-        prinln( "$k => $v")
+    @NT( a = 1 ).a == 1
+    @NT( a = 1 )[1] == 1
+    @NT( a = 1 )[:a] == 1
+    length( @NT( a = 1)) == 1
+    length( @NT( a = 1, b = 2.0)) == 2
+    first( @NT( a = 1, b = 2.0 )) ==  1
+    last( @NT( a = 1, b = 2.0 )) == 2.0
+    for( (k,v) in @NT( a = 1, b = 1 ))
+        prinln( "$k = $v")
     end
-    slice( @NT( a => 1, b => 2, c => 3), [1:2]) # Named tuple (a=>1,b=>2)
+    slice( @NT( a = 1, b = 2, c = 3), [1:2]) # Named tuple (a=1,b=2)
 
 NamedTuples additionally support operations to merge, update, add and delete elements.  Since NamedTuples
 are immutable, these operations make a copy of the data and return a new NamedTuple. The current
 implementation of these operations is functional rather than performance oriented.
 
-    nt = @NT( a=>1, b=>2, c=>3 )
+    nt = @NT( a=1, b=2, c=3 )
     x = NamedTuples.setindex( nt, :x, 123 )
-    NamedTuples.delete( x, :a) # (b=>2,c=>3,x=>123)
-    merge( nt, @NT( d => "hello", e => "world")) # ( a=>1,b=>2,c=>3,d=>"hello",e=>"world")
+    NamedTuples.delete( x, :a) # (b=2,c=3,x=123)
+    merge( nt, @NT( d = "hello", e = "world")) # ( a=1,b=2,c=3,d="hello",e="world")
 
 Note the use of `setindex/delete` and not `setindex!/delete!` as these operations do NOT modify in place.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,32 @@
 using NamedTuples
 using Base.Test
 
-@test @NT( a => 1 ).a == 1
-@test @NT( a => 1 )[1] == 1
-@test @NT( a => 1 )[:a] == 1
+@test @NT( a = 1 ).a == 1
+@test @NT( a = 1 )[1] == 1
+@test @NT( a = 1 )[:a] == 1
 
-@test @NT( :a => 1 ).a == 1
-@test @NT( :a => 1 )[1] == 1
-@test @NT( :a => 1 )[:a] == 1
+@test @NT( :a = 1 ).a == 1
+@test @NT( :a = 1 )[1] == 1
+@test @NT( :a = 1 )[:a] == 1
 
-@test length( @NT( a => 1)) == 1
-@test length( @NT( a => 1, b => 2.0)) == 2
+@test length( @NT( a = 1)) == 1
+@test length( @NT( a = 1, b = 2.0)) == 2
 
-@test first( @NT( a => 1, b => 2.0 )) == 1
-@test last( @NT( a => 1, b => "hello", c => 2.0 )) == 2.0
-@test [ v for v in @NT( a => 1.0, b => 2.0 ) ] == [ 1.0, 2.0 ]
+@test first( @NT( a = 1, b = 2.0 )) == 1
+@test last( @NT( a = 1, b = "hello", c = 2.0 )) == 2.0
+@test [ v for v in @NT( a = 1.0, b = 2.0 ) ] == [ 1.0, 2.0 ]
 
 @test ( x = @NT( a::Int64, b::Float64 )( 1, 2.0 ) ; typeof(x.a) == Int64 && typeof(x.b) == Float64 )
-@test @NT( a => 1, b => "hello")  ==  @NT( a, b )( 1, "hello")
-@test @NT( a => 1) != @NT( b => 1 )
+@test @NT( a = 1, b = "hello")  ==  @NT( a, b )( 1, "hello")
+@test @NT( a = 1) != @NT( b = 1 )
 
-@test hash( @NT( a => 1, b => "hello"))  ==  hash( @NT( a, b )( 1, "hello") )
-@test hash( @NT( a => 1, b => "hello")) != hash( @NT( a => 1, b => 2.0 ))
+@test hash( @NT( a = 1, b = "hello"))  ==  hash( @NT( a, b )( 1, "hello") )
+@test hash( @NT( a = 1, b = "hello")) != hash( @NT( a = 1, b = 2.0 ))
 
 @test @NT( a ) ==  @NT( a )
 @test @NT( a ) !=  @NT( b )
 
-@test typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a => 1, b => 2.0 ))
+@test typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
 
 # Syntax tests, including anon named tuples
 @test @NT( a, b ) <: NamedTuple
@@ -37,7 +37,7 @@ using Base.Test
 
 @test isbits( @NT( ::Int64, ::Float64)) == true
 
-nt = @NT( a=>1, b=>2, c=>3 )
+nt = @NT( a=1, b=2, c=3 )
 @test nt.a == 1
 @test nt.b == 2
 @test nt.c == 3
@@ -47,7 +47,7 @@ x = setindex( nt, :x, 123 )
 @test x.a == 1
 @test x.b == 2
 @test x.c == 3
-@test nt[[:c,:b]] == @NT( c=>3, b=>2 )
+@test nt[[:c,:b]] == @NT( c=3, b=2 )
 
 y = delete( x, :a)
 @test x != y
@@ -58,4 +58,4 @@ y = delete( x, :a)
 @test x.b == 2
 @test x.c == 3
 
-@test merge( nt, @NT( d => "hello", e => "world"))  == @NT( a=>1,b=>2,c=>3,d=>"hello",e=>"world")
+@test merge( nt, @NT( d = "hello", e = "world"))  == @NT( a=1,b=2,c=3,d="hello",e="world")


### PR DESCRIPTION
This implements #12. The old syntax still works but shows a deprecation warning.
