### PR TITLE
Fix the naming scheme for the generated types

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -96,7 +96,8 @@ end
 # this is only done if the tuple has not already been
 # constructed.
 function create_tuple( fields::Vector{Symbol})
-    name = Symbol( string( "_NT_", join( fields)) )
+    escaped_fieldnames = [replace(string(i), "_", "__") for i in fields]
+    name = Symbol( string( "_NT_", join( escaped_fieldnames, "_")) )
     if !isdefined(NamedTuples, name)
         len = length( fields )
         types = [Symbol("T$n") for n in 1:len]


### PR DESCRIPTION
This doesn't work
````julia
@NT(a=>1, b=>2)
@NT(ab=>3)
````
because it will try to use the same type for both cases.

This PR fixes that by 1) separating field names with ``_`` in the type name, and 2) replacing any single ``_`` in a member name with two ``_``. I think that should be enough to prevent any naming collisions.