### PR TITLE
fixes for 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.4
+julia 0.5.0-
+Compat 0.17.0


### PR DESCRIPTION
This gets the tests passing on julia master.

- Remove the `Associative` supertype. NamedTuples don't quite act like other Associative types; in particular they don't iterate `key=>value` pairs, so I just removed the declaration for now.
- Remove `slice`, which was deprecated. It can just be a method of `getindex`.
- Update macro for change in parsing of `=>`.
- The tricky bit: NamedTuples makes new types at runtime, and the world counter generally prevents their constructors from being called, since those methods are added too late. My fix for this is to define a fixed set of constructors to be shared by all NamedTuples (since they all have very similar behavior of just copying arguments to fields), and suppress generation of default constructors. I have specializations for 0-5 arguments, and a generated function for others.
