### PR TITLE
Add dot broadcast support

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -321,6 +321,8 @@ end
 
 Base.Broadcast._containertype(::Type{<:NamedTuple}) = NamedTuple
 Base.Broadcast.promote_containertype(::Type{NamedTuple}, ::Type{NamedTuple}) = NamedTuple
+Base.Broadcast.promote_containertype(::Type{NamedTuple}, _) = error()
+Base.Broadcast.promote_containertype(_, ::Type{NamedTuple}) = error()
 
 @inline function Base.Broadcast.broadcast_c(f, ::Type{NamedTuple}, nts...)
     _map(f, nts...)

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -319,6 +319,13 @@ function delete( t::NamedTuple, key::Symbol )
     return getfield(NamedTuples, name)(vals...)
 end
 
+Base.Broadcast._containertype(::Type{<:NamedTuple}) = NamedTuple
+Base.Broadcast.promote_containertype(::Type{NamedTuple}, ::Type{NamedTuple}) = NamedTuple
+
+@inline function Base.Broadcast.broadcast_c(f, ::Type{NamedTuple}, nts...)
+    _map(f, nts...)
+end
+
 export @NT, NamedTuple, setindex, delete
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,3 +65,7 @@ y = delete( x, :a)
 @test map(round, @NT(x=1//3, y=Int), @NT(x=3, y=2//3)) == @NT(x=0.333, y=1)
 
 @test merge( nt, @NT( d = "hello", e = "world"))  == @NT( a=1,b=2,c=3,d="hello",e="world")
+
+@test get.(@NT( a = Nullable(3), b = Nullable("world") )) == @NT( a = 3, b = "world")
+@test_throws MethodError @NT( a = 3) .+ [4]
+@test_throws MethodError [4] .+ @NT( a = 3)


### PR DESCRIPTION
@TotalVerb Can I ask for your help again with this :) I think in this case it seems the most conservative approach to at first only allow broadcasting when all the sources are ``NamedTuple``s, i.e. not allow mixed ``NamedTuple`` and other container type style broadcasting. Did I achieve that with the below code?

I guess the other question is whether the use of ``_map`` is ok here... Ideally I would like the dot broadcasting syntax here to actually *not* broadcast, but work more like ``map``.

@shashi Any opinions about that? You wrote the ``map`` code originally, so your input would be great.