### PR TITLE
[WIP] Make merge typestable

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -291,12 +291,23 @@ Merge two NamedTuples favoring the lhs
 Order is preserved lhs names come first.
 This copies the underlying data.
 """ ->
-function Base.merge( lhs::NamedTuple, rhs::NamedTuple )
-    nms = unique( vcat( fieldnames( lhs ), fieldnames( rhs )) )
-    name = create_tuple( nms )
-    # FIXME should handle the type only case
-    vals = [ haskey( lhs, nm ) ? lhs[nm] : rhs[nm] for nm in nms ]
-    getfield(NamedTuples,name)(vals...)
+@generated function Base.merge( lhs::NamedTuple, rhs::NamedTuple )
+    field_assignments = Expr[]
+    names_from_left = Set{Symbol}()
+    for i in fieldnames(lhs)
+        push!(field_assignments, Expr(:(=), i, Expr(:., :lhs, QuoteNode(i))))
+        push!(names_from_left, i)
+    end
+
+    for i in fieldnames(rhs)
+        if !(i in names_from_left)
+            push!(field_assignments, Expr(:(=), i, Expr(:., :rhs, QuoteNode(i))))
+        end
+    end
+
+    constructor_call = Expr(:macrocall, Symbol("@NT"), field_assignments...)
+
+    return constructor_call
 end
 
 @doc doc"""


### PR DESCRIPTION
This doesn't work and it is probably because I'm misusing generated functions once again, but I don't really understand why this is not working. The way I think this should work is this:
````julia
using NamedTuples

A = @NT(a=2)
B = @NT(b=2)

merge(A,B)
````
I get an error message "ERROR: eval cannot be used in a generated function" from that. But, as far as I can tell I'm actually not calling ``eval`` in the generated function, all I'm doing is I'm returning a quoted expression that has a macrocall to ``@NT`` in it. Now the ``@NT`` macro calls ``eval`` (sometimes), so I assume that is the problem? Any other ideas for this situation?

@JeffBezanson @vtjnash @shashi 