### PR TITLE
Segfault when including NameTuples in pre-compiled packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,7 @@ implementation of these operations is functional rather than performance oriente
 
 Note the use of `setindex/delete` and not `setindex!/delete!` as these operations do NOT modify in place.
 
+
+Warning: Currently, it is not possible to use NameTuples within precompiled packages.
+
 [![Build Status](https://travis-ci.org/blackrock/NamedTuples.jl.svg?branch=master)](https://travis-ci.org/blackrock/NamedTuples.jl)

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -1,5 +1,6 @@
 __precompile__()
 module NamedTuples
+__init__() = __precompile__(false)
 
 abstract type NamedTuple end
 


### PR DESCRIPTION
This pull-request addresses #27 without solving it.

It adds `__init__() = __precompile__(false)` as per @vtjnash's comment. That gets rid of the segfault and provides an error message that might be meaningful to those further along the Julia dao than myself.

It also adds an explicit warning in the README.

Closes #27 
