### PR TITLE
fix serialization of Union{}

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -359,7 +359,9 @@ immutable NTType end
 immutable NTVal end
 
 function Base.serialize{NT<:NamedTuple}(io::AbstractSerializer, ::Type{NT})
-    if isa(NT, Union)
+    if NT === Union{}
+        Base.Serializer.write_as_tag(io, Base.Serializer.BOTTOM_TAG)
+    elseif isa(NT, Union)
         Base.serialize_type(io, NTType)
         serialize(io, Union)
         serialize(io, [uniontypes(NT)...])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,3 +81,7 @@ y = @fetchfrom 2 identity(x)
 @test isa(y,NamedTuple)
 @test y.a == 1
 @test y.b == 2
+
+io = IOBuffer()
+serialize(io, Union{})
+@test deserialize(seekstart(io)) === Union{}


### PR DESCRIPTION
 which was getting trapped in `serialize` method for`Type{<:NamedTuple}`.