### PR TITLE
Ensure type-stability of == and hash

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -36,7 +36,7 @@ Base.get( t::NamedTuple, i::Symbol, default ) = i in keys(t) ? t[i] : default
 import Base: ==
 
 @generated function ==( lhs::NamedTuple, rhs::NamedTuple)
-    if !isequal(fieldnames(lhs), fieldnames(rhs))
+    if !isequal(fieldnames(lhs), fieldnames(rhs)) || lhs !== rhs
         return false
     end
 

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -33,7 +33,6 @@ Base.getindex( t::NamedTuple, i::Symbol, default ) = get( t, i, default )
 # This is a linear lookup...
 Base.get( t::NamedTuple, i::Symbol, default ) = i in keys(t) ? t[i] : default
 # Deep compare
-
 import Base: ==
 
 @generated function ==( lhs::NamedTuple, rhs::NamedTuple)
@@ -41,24 +40,26 @@ import Base: ==
         return false
     end
 
-    quote
-        ( lhs === rhs ) && return true
-        for i in 1:length( lhs )
-            if ( lhs[i] != rhs[i])
-                return false
-            end
-        end
-        return true
+    q = quote end
+    
+    for i in 1:length( fieldnames(lhs) )
+        push!(q.args, :(lhs[$(i)] == rhs[$(i)] || return false))
     end
-end
-# Deep hash
 
-function Base.hash( nt::NamedTuple, hs::UInt64)
-    h = 17
-    for v in values(nt)
-        h = h * 23 + hash( v, hs )
+    return q 
+end
+
+# Deep hash
+@generated function Base.hash(nt::NamedTuple, hs::UInt64)
+    q = quote 
+        h = 17
     end
-    return h
+
+    for i in 1:length(fieldnames(nt))
+        push!(q.args, :(h = h * 23 + hash(nt[$(i)], hs)))
+    end
+
+    return q
 end
 
 


### PR DESCRIPTION
@davidanthoff and I discovered that the == and hash functions were not type-stable.  This PR should remedy that and improve performance.  I quickly took a few screenshots comparing the native code of the original to the new:

Original:
![== original](https://user-images.githubusercontent.com/6109885/35881362-6b1d68f8-0b35-11e8-9b3c-4da5902d2220.png)
![hash original](https://user-images.githubusercontent.com/6109885/35881363-6b35e216-0b35-11e8-9228-9aff5cac77cc.png)

New:
![== new](https://user-images.githubusercontent.com/6109885/35881390-7edaba94-0b35-11e8-80ee-ebad10c3623f.png)
![hash new](https://user-images.githubusercontent.com/6109885/35881389-7ec1135a-0b35-11e8-9828-203d94300273.png)

