### PR TITLE
Minimal changes to work on Julia 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # NamedTuples
 
+## Note: the [Named Tuple type](https://docs.julialang.org/en/v1/manual/types/#Named-Tuple-Types-1) functionality has been integrated into Julia Base as of Julia 0.7. Prefer using the Base implementation of NamedTuples when writing code for Julia 0.7 or higher.
+
 NamedTuples.jl provides a high performance implementation of named tuples for Julia (cf named tuples in python). Julia tuples are restricted to supporting index based access. This new implementation allows both index and property based access. NamedTuples may be used anywhere that a tuple is currently being used, for example in the definition of a method or as the return value of a method. NamedTuples are implemented using Julia’s macro system, ensuring that the run time cost is equivalent to constructing a regular immutable type.
 
 NamedTuples may also be used in cases where a small typed immutable dictionary is desired.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Syntax
 ```julia
 @NT( a, b )                 -> Defines a tuple with a and b as members
 @NT( a::Int64, b::Float64 ) -> Defines a tuple with the specific arg types as members
-@NT( a = 1, b = "hello")  -> Defines and constructs a tuple with the specifed members and values
-@NT( a, b )( 1, "hello")    -> Is equivalent to the above definition
-@NT( a::Int64 )( 2.0 )      -> Calls `convert( Int64, 2.0 )` on construction and sets `a`
+@NT( a = 1, b = "hello")    -> Defines and constructs a tuple with the specifed members and values
+@NT( a, b )( (1, "hello") ) -> Is equivalent to the above definition
+@NT( a::Int64 )( (2.0,) )   -> Calls `convert( Int64, 2.0 )` on construction and sets `a`
 @NT( ::Int64, ::Float64 )   -> Defines a named tuple with automatic names
 ```
 
 NamedTuples may be used anywhere you would use a regular Tuple, this includes method definition and return values.
 
 ```julia
-module Test
+module Demo
 using NamedTuples
 
 function foo( y )
@@ -30,20 +30,21 @@ function foo( y )
     x = 3
     return  @NT( a = 1, b = "world", c = "hello", d=a/x, y = a/y  )
 end
-function bar( nt::@NT( a::Int64, c::ASCIIString ))
+function bar( nt::@NT( a::Int64, c::String ))
     return repeat( nt.c, nt.a )
 end
 
 end
 
-Test.foo( 1 ) # Returns a NamedTuple of 5 elements
-Test.bar( @NT( a= 2, c="hello")) # Returns `hellohello`
+using NamedTuples
+Demo.foo( 1 ) # Returns a NamedTuple of 5 elements
+Demo.bar( @NT( a= 2, c="hello")) # Returns `hellohello`
 ```
 
 There is at most one instance of a NamedTuple type with a given set of Members and Types, hence
 
 ```julia
-typeof( @NT( a::Int, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
+typeof( @NT( a = 1, b = 2.0 )) == @NT( a::Int, b::Float64 )
 ```
 
 NamedTuple definitions are shared across all modules. The underlying immutable types are constructed at first use.
@@ -58,10 +59,10 @@ length( @NT( a = 1)) == 1
 length( @NT( a = 1, b = 2.0)) == 2
 first( @NT( a = 1, b = 2.0 )) ==  1
 last( @NT( a = 1, b = 2.0 )) == 2.0
-for( (k,v) in @NT( a = 1, b = 1 ))
-    prinln( "$k = $v")
+using Compat: pairs
+for (k,v) in pairs(@NT( a = 1, b = 1 ))
+    println("$k = $v")
 end
-slice( @NT( a = 1, b = 2, c = 3), [1:2]) # Named tuple (a=1,b=2)
 ```
 
 NamedTuples additionally support operations to merge, update, add and delete elements.  Since NamedTuples
@@ -69,10 +70,17 @@ are immutable, these operations make a copy of the data and return a new NamedTu
 implementation of these operations is functional rather than performance oriented.
 
 ```julia
-nt = @NT( a=1, b=2, c=3 )
-x = NamedTuples.setindex( nt, :x, 123 )
-NamedTuples.delete( x, :a) # (b=2,c=3,x=123)
-merge( nt, @NT( d = "hello", e = "world")) # ( a=1,b=2,c=3,d="hello",e="world")
+julia> nt = @NT( a=1, b=2, c=3 )
+(a = 1, b = 2, c = 3)
+
+julia> x = NamedTuples.setindex( nt, :x, 123 )
+(a = 1, b = 2, c = 3, x = 123)
+
+julia> NamedTuples.delete( x, :a)
+(b = 2, c = 3, x = 123)
+
+julia> merge( nt, @NT( d = "hello", e = "world"))
+(a = 1, b = 2, c = 3, d = "hello", e = "world")
 ```
 
 Note the use of `setindex/delete` and not `setindex!/delete!` as these operations do NOT modify in place.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.7

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -376,7 +376,7 @@ Base.Broadcast.promote_containertype(_, ::Type{NamedTuple}) = error()
     _map(f, nts...)
 end
 
-else
+elseif VERSION < v"0.7.0-DEV.4955"
 
 @inline function Base.Broadcast.broadcast(f, nt::NamedTuple)
     map(f, nt)

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -6,6 +6,8 @@ export @NT, NamedTuple, setindex, delete
 moduleof(t::DataType) = t.name.module
 moduleof(t::UnionAll) = moduleof(Base.unwrap_unionall(t))
 
+if VERSION < v"0.7.0-DEV.2738"
+
 abstract type NamedTuple end
 
 Base.keys( t::NamedTuple ) = fieldnames( t )
@@ -65,6 +67,7 @@ end
     return q
 end
 
+end
 
 # Helper type, for transforming parse tree to NameTuple definition
 struct ParseNode{T} end
@@ -104,6 +107,10 @@ function trans( sym::Symbol )
     return (sym, nothing, nothing)
 end
 
+function trans( qt::QuoteNode )
+    return (qt.value, nothing)
+end
+
 function trans( ::Type{ParseNode{:quote}}, expr::Expr )
     return trans( expr.args[1] )
 end
@@ -116,6 +123,8 @@ end
 function trans{T}( ::Type{ParseNode{T}}, expr::Expr)
     return (nothing, nothing, expr)
 end
+
+if VERSION < v"0.7.0-DEV.2738"
 
 function gen_namedtuple_ctor_body(n::Int, args)
     types = [ :(typeof($x)) for x in args ]
@@ -139,19 +148,15 @@ function gen_namedtuple_ctor_body(n::Int, args)
 end
 
 # constructor for all NamedTuples
-@generated function (::Type{NT}){NT<:NamedTuple}(args...)
-    n = length(args)
+@generated function (::Type{NT})(args::Tuple) where {NT <: NamedTuple}
+    n = length(args.parameters)
     aexprs = [ :(args[$i]) for i = 1:n ]
-    return gen_namedtuple_ctor_body(n, aexprs)
+    gen_namedtuple_ctor_body(n, aexprs)
 end
 
-# specialized for certain argument counts
-for n = 0:5
-    args = [ Symbol("x$n") for n = 1:n ]
-    @eval function (::Type{NT}){NT<:NamedTuple}($(args...))
-        $(gen_namedtuple_ctor_body(n, args))
-    end
 end
+
+if VERSION < v"0.7.0-DEV.2738"
 
 # Create a NameTuple type, if a type with these field names has not already been
 # constructed.
@@ -173,6 +178,12 @@ function create_namedtuple_type(fields::Vector{Symbol}, mod::Module = NamedTuple
         eval(mod, def)
     end
     return getfield(mod, name)
+end
+
+else
+
+create_namedtuple_type(fields::Vector{Symbol}) = NamedTuple{tuple(fields...)}
+
 end
 
 #
@@ -217,9 +228,13 @@ function make_tuple( exprs::Vector)
         if len == 0
             return ty
         end
-        return Expr( :curly, ty, typs... )
+        if VERSION < v"0.7.0-DEV.2738"
+            return Expr(:curly, ty, typs...)
+        else
+            return Expr(:curly, ty, Expr(:curly, :Tuple, typs...))
+        end
     else
-        return Expr( :call, ty, values ... )
+        return Expr( :call, ty, Expr(:tuple, values...) )
     end
 end
 
@@ -255,6 +270,9 @@ macro NT( expr... )
     return esc(make_tuple( collect( expr )))
 end
 
+
+if VERSION < v"0.7.0-DEV.2738"
+
 @inline function Base.map(f, nt::NamedTuple, nts::NamedTuple...)
     # this method makes sure we don't define a map(f) method
     _map(f, nt, nts...)
@@ -274,7 +292,7 @@ end
     NT = create_namedtuple_type(fields, moduleof(nts[1]))
     args = Expr[:(f($(Expr[:(getfield(nts[$i], $j)) for i = 1:M]...))) for j = 1:N]
     quote
-        $NT($(args...))
+        $NT(($(args...),))
     end
 end
 
@@ -294,12 +312,6 @@ end
     end
 end
 
-function Base.getindex( t::NamedTuple, rng::AbstractVector )
-    names = unique( Symbol[ isa(i,Symbol) ? i : fieldname(typeof(t),i) for i in rng ] )
-    ty = create_namedtuple_type( names )
-    ty([ getfield( t, i ) for i in names ]...)
-end
-
 @doc doc"""
 Merge two NamedTuples favoring the lhs
 Order is preserved lhs names come first.
@@ -309,8 +321,16 @@ function Base.merge( lhs::NamedTuple, rhs::NamedTuple )
     nms = unique( vcat( fieldnames( lhs ), fieldnames( rhs )) )
     ty = create_namedtuple_type( nms )
     # FIXME should handle the type only case
-    vals = [ haskey( lhs, nm ) ? lhs[nm] : rhs[nm] for nm in nms ]
-    ty(vals...)
+    vals = tuple([ haskey( lhs, nm ) ? lhs[nm] : rhs[nm] for nm in nms ]...)
+    ty(vals)
+end
+
+end
+
+function Base.getindex( t::NamedTuple, rng::AbstractVector )
+    names = unique( Symbol[ isa(i,Symbol) ? i : fieldname(typeof(t),i) for i in rng ] )
+    ty = create_namedtuple_type( names )
+    ty(tuple([getfield(t, i) for i in names]...))
 end
 
 @doc doc"""
@@ -319,7 +339,7 @@ the old value or appending a new value.
 This copies the underlying data.
 """ ->
 function setindex{V}( t::NamedTuple, key::Symbol, val::V)
-    nt = create_namedtuple_type( [key] )( val )
+    nt = create_namedtuple_type( [key] )( (val,) )
     return merge( t, nt )
 end
 
@@ -327,11 +347,13 @@ end
 Create a new NamedTuple with the specified element removed.
 """ ->
 function delete( t::NamedTuple, key::Symbol )
-    nms = filter( x->x!=key, fieldnames( t ) )
+    nms = filter(x -> x != key, collect(fieldnames(t)))
     ty = create_namedtuple_type( nms )
-    vals = [ getindex( t, nm ) for nm in nms ]
-    return ty(vals...)
+    vals = tuple([getindex(t, nm) for nm in nms]...)
+    return ty(vals)
 end
+
+if VERSION < v"0.7.0-DEV.2738"
 
 Base.Broadcast._containertype(::Type{<:NamedTuple}) = NamedTuple
 Base.Broadcast.promote_containertype(::Type{NamedTuple}, ::Type{NamedTuple}) = NamedTuple
@@ -341,6 +363,16 @@ Base.Broadcast.promote_containertype(_, ::Type{NamedTuple}) = error()
 @inline function Base.Broadcast.broadcast_c(f, ::Type{NamedTuple}, nts...)
     _map(f, nts...)
 end
+
+else
+
+@inline function Base.Broadcast.broadcast(f, nt::NamedTuple)
+    map(f, nt)
+end
+
+end
+
+if VERSION < v"0.7.0-DEV.2738"
 
 struct NTType end
 struct NTVal end
@@ -400,16 +432,20 @@ function Base.deserialize(io::AbstractSerializer, ::Type{NTVal})
     NT = deserialize(io)
     nf = nfields(NT)
     if nf == 0
-        return NT()
+        return NT(())
     elseif nf == 1
-        return NT(deserialize(io))
+        return NT(tuple(deserialize(io)))
     elseif nf == 2
-        return NT(deserialize(io), deserialize(io))
+        return NT(tuple(deserialize(io), deserialize(io)))
     elseif nf == 3
-        return NT(deserialize(io), deserialize(io), deserialize(io))
+        return NT(tuple(deserialize(io), deserialize(io), deserialize(io)))
     else
-        return NT(Any[ deserialize(io) for i = 1:nf ]...)
+        return NT(tuple(Any[ deserialize(io) for i = 1:nf ]...))
     end
 end
+
+end
+
+include("deprecated.jl")
 
 end # module

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -157,6 +157,18 @@ end
 end
 
 if VERSION < v"0.7.0-DEV.2738"
+    function (::Type{NT})(itr) where {NT <: NamedTuple}
+        T = isa(NT, DataType) ? Tuple{NT.parameters...} : Tuple
+        NT(T(itr))
+    end
+else
+    # TODO: Will need to be wrapped in a VERSION check when
+    # https://github.com/JuliaLang/julia/pull/26914 is merged
+    NamedTuple{names, T}(itr) where {names, T <: Tuple} = NamedTuple{names, T}(T(itr))
+    NamedTuple{names}(itr) where {names} = NamedTuple{names}(Tuple(itr))
+end
+
+if VERSION < v"0.7.0-DEV.2738"
 
 # Create a NameTuple type, if a type with these field names has not already been
 # constructed.

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,27 @@
+# BEGIN NamedTuples 4.1.0 deprecations
+
+if VERSION < v"0.7.0-DEV.2738"
+    # Deprecate `@NT( a::Int64, b::Float64 )( 1, 2.0 )` syntax. Note that we're avoiding
+    # creating these functions on Julia 0.7 as NamedTuples.jl previously did not work and
+    # doesn't require the deprecation.
+
+    @generated function (::Type{NT})(args...) where {NT <: NamedTuple}
+        Base.depwarn("`$NT(args...)` is deprecated, use `$NT((args...,))` instead.",
+                     Symbol("NamedTuple(args...)"))
+        n = length(args)
+        aexprs = [ :(args[$i]) for i = 1:n ]
+        return gen_namedtuple_ctor_body(n, aexprs)
+    end
+
+    # specialized for certain argument counts
+    for n = 0:5
+        args = [ Symbol("x$n") for n = 1:n ]
+        @eval function (::Type{NT})($(args...)) where {NT <: NamedTuple}
+            Base.depwarn("`$NT(args...)` is deprecated, use `$NT((args...,))` instead.",
+                         Symbol("NamedTuple(args...)"))
+            $(gen_namedtuple_ctor_body(n, args))
+        end
+    end
+end
+
+# END NamedTuples 4.1.0 deprecations

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,17 +1,17 @@
-# BEGIN NamedTuples 4.1.0 deprecations
+# BEGIN NamedTuples 5.0.0 deprecations
 
 if VERSION < v"0.7.0-DEV.2738"
-    # Deprecate `@NT( a::Int64, b::Float64 )( 1, 2.0 )` syntax. Note that we're avoiding
-    # creating these functions on Julia 0.7 as NamedTuples.jl previously did not work and
-    # doesn't require the deprecation.
+    # Create a nicer error message for the breaking change to the
+    # `@NT( a::Int64, b::Float64 )( 1, 2.0 )` syntax. Note that we will avoid creating
+    # this error on Julia 0.7 as NamedTuples.jl previously did not work and won't require
+    # the deprecation.
 
-    @generated function (::Type{NT})(args...) where {NT <: NamedTuple}
-        Base.depwarn("`$NT(args...)` is deprecated, use `$NT((args...,))` instead.",
-                     Symbol("NamedTuple(args...)"))
-        n = length(args)
-        aexprs = [ :(args[$i]) for i = 1:n ]
-        return gen_namedtuple_ctor_body(n, aexprs)
+    function (::Type{NT})(args...) where {NT <: NamedTuple}
+        error(string(
+            "`$NT(args...)` is no longer supported as it is ambiguous with the new " *
+            "`$NT((args...,))` constructor."
+        ))
     end
 end
 
-# END NamedTuples 4.1.0 deprecations
+# END NamedTuples 5.0.0 deprecations

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -12,16 +12,6 @@ if VERSION < v"0.7.0-DEV.2738"
         aexprs = [ :(args[$i]) for i = 1:n ]
         return gen_namedtuple_ctor_body(n, aexprs)
     end
-
-    # specialized for certain argument counts
-    for n = 0:5
-        args = [ Symbol("x$n") for n = 1:n ]
-        @eval function (::Type{NT})($(args...)) where {NT <: NamedTuple}
-            Base.depwarn("`$NT(args...)` is deprecated, use `$NT((args...,))` instead.",
-                         Symbol("NamedTuple(args...)"))
-            $(gen_namedtuple_ctor_body(n, args))
-        end
-    end
 end
 
 # END NamedTuples 4.1.0 deprecations

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+Nullables

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,10 @@ y = delete( x, :a)
 
 @test merge( nt, @NT( d = "hello", e = "world"))  == @NT( a=1,b=2,c=3,d="hello",e="world")
 
-@test get.(@NT( a = Nullable(3), b = Nullable("world") )) == @NT( a = 3, b = "world")
+# TODO: Support new broadcasting interface (https://github.com/JuliaLang/julia/pull/26891)
+if VERSION < v"0.7.0-DEV.4955"
+    @test get.(@NT( a = Nullable(3), b = Nullable("world") )) == @NT( a = 3, b = "world")
+end
 @test_throws MethodError @NT( a = 3) .+ [4]
 @test_throws MethodError [4] .+ @NT( a = 3)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,3 +116,7 @@ module B
 end
 
 @test A.NT === B.NT
+
+# Iterator constructor
+@test @NT(a::Int, b::Float64)(Any[1.0, 2]) === @NT(a=1, b=2.0)
+@test @NT(a, b)(Any[1.0, 2]) === @NT(a=1.0, b=2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using NamedTuples
+using Nullables
 using Base.Test
 
 @test @NT( a = 1 ).a == 1
@@ -21,12 +22,12 @@ using Base.Test
 @test last( @NT( a = 1, b = "hello", c = 2.0 )) == 2.0
 @test [ v for v in @NT( a = 1.0, b = 2.0 ) ] == [ 1.0, 2.0 ]
 
-@test ( x = @NT( a::Int64, b::Float64 )( 1, 2.0 ) ; typeof(x.a) == Int64 && typeof(x.b) == Float64 )
-@test @NT( a = 1, b = "hello")  ==  @NT( a, b )( 1, "hello")
+@test ( x = @NT( a::Int64, b::Float64 )( (1, 2.0) ) ; typeof(x.a) == Int64 && typeof(x.b) == Float64 )
+@test @NT( a = 1, b = "hello")  ==  @NT( a, b )((1, "hello"))
 @test @NT( a = 1) != @NT( b = 1 )
 @test @NT(a=1) == @NT(a=1.)
 
-@test hash( @NT( a = 1, b = "hello"))  ==  hash( @NT( a, b )( 1, "hello") )
+@test hash( @NT( a = 1, b = "hello"))  ==  hash( @NT( a, b )((1, "hello")) )
 @test hash( @NT( a = 1, b = "hello")) != hash( @NT( a = 1, b = 2.0 ))
 
 @test @NT( a ) ==  @NT( a )
@@ -34,7 +35,7 @@ using Base.Test
 
 @test @NT(a::Int, b) == @NT(a::Int, b::Any)
 
-@test typeof( @NT( a::Int, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
+@test typeof( @NT( a::Int, b::Float64 )((1, 3.0)) ) == typeof( @NT( a = 1, b = 2.0 ))
 
 # Syntax tests, including anon named tuples
 @test @NT( a, b ) <: NamedTuple
@@ -97,7 +98,11 @@ serialize(io, Union{})
 # allow custom types
 struct Empty end
 nt = @NT(a::Empty, b::Int)
-@test nt.parameters[1] == Empty
+if VERSION < v"0.7.0-DEV.2738"
+    @test nt.parameters[1] == Empty
+else
+    @test nt.parameters[2] == Tuple{Empty, Int}
+end
 
 # type reuse
 module A


### PR DESCRIPTION
Uses the minimal required changes from #52 to support named tuples on Julia 0.6 and use built-in named tuples on Julia 0.7.

To properly support the build-in named tuples on Julia 0.7 we needed to deprecate the constructor `(::Type{NT})(args...) where {NT <: NamedTuple}` which is ambiguous with the `NamedTuple{...}(t::Tuple)` when a single tuple is passed in. Unfortunately making this change is breaking as the behaviour of `@NT(a)((1,))` will be `(a=(1,),)` with the old constructor and `(a=1,)` with the new one.

I'll also note I did not indent code with VERSION blocks as it made the diff hard to read. I can either add the indentation in another PR or as an additional commit to this PR.