### PR TITLE
Address world age issues with using moduleof

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -3,6 +3,9 @@ module NamedTuples
 
 export @NT, NamedTuple, setindex, delete
 
+moduleof(t::DataType) = t.name.module
+moduleof(t::UnionAll) = moduleof(Base.unwrap_unionall(t))
+
 abstract type NamedTuple end
 
 Base.keys( t::NamedTuple ) = fieldnames( t )
@@ -347,15 +350,6 @@ Base.Broadcast.promote_containertype(_, ::Type{NamedTuple}) = error()
     _map(f, nts...)
 end
 
-moduleof(t::DataType) = t.name.module
-
-if VERSION < v"0.6.0-dev"
-    uniontypes(u) = u.types
-else
-    const uniontypes = Base.uniontypes
-    moduleof(t::UnionAll) = moduleof(Base.unwrap_unionall(t))
-end
-
 struct NTType end
 struct NTVal end
 
@@ -365,7 +359,7 @@ function Base.serialize{NT<:NamedTuple}(io::AbstractSerializer, ::Type{NT})
     elseif isa(NT, Union)
         Base.serialize_type(io, NTType)
         serialize(io, Union)
-        serialize(io, [uniontypes(NT)...])
+        serialize(io, [Base.uniontypes(NT)...])
     elseif isleaftype(NT)
         Base.serialize_type(io, NTType)
         serialize(io, fieldnames(NT))


### PR DESCRIPTION
While verifying #46 by including NamedTuples.jl in a system image I encountered:
```julia
INFO: Testing NamedTuples
Error During Test
  Test threw an exception of type MethodError
  Expression: map(-, @NT(x = 1, y = 2)) == @NT(x = -1, y = -2)
  MethodError: no method matching moduleof(::Type{NamedTuples._NT_x_y{Int64,Int64}})
  The applicable method may be too new: running in world age 21885, while current world is 21909.
  Closest candidates are:
    moduleof(::DataType) at /root/.julia/v0.6/NamedTuples/src/NamedTuples.jl:350 (method too new to be called from this world context.)
    moduleof(!Matched::UnionAll) at /root/.julia/v0.6/NamedTuples/src/NamedTuples.jl:356 (method too new to be called from this world context.)
  Stacktrace:
   [1] _map(...) at /root/.julia/v0.6/NamedTuples/src/NamedTuples.jl:279
   [2] map(::Function, ::NamedTuples._NT_x_y{Int64,Int64}) at /root/.julia/v0.6/NamedTuples/src/NamedTuples.jl:265
   [3] include_from_node1(::String) at ./loading.jl:576
   [4] include(::String) at ./sysimg.jl:14
   [5] process_options(::Base.JLOptions) at ./client.jl:305
   [6] _start() at ./client.jl:371
ERROR: LoadError: There was an error during testing
while loading /root/.julia/v0.6/NamedTuples/test/runtests.jl, in expression starting on line 63
```
This PR addresses this world age issue.