### PR TITLE
Fix incremental compilation, again

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -256,9 +256,54 @@ NamedTuples may be used anywhere you would use a regular Tuple, this includes me
     Test.foo( 1 ) # Returns a NamedTuple of 5 elements
     Test.bar( @NT( a= 2, c="hello")) # Returns `hellohello`
 """ ->
-macro NT( expr... )
-    return esc(make_tuple( collect( expr )))
+macro NT(exprs...)
+    len    = length( exprs )
+    fields = Array{QuoteNode}(len)
+    values = Array{Any}(len)
+    typs   = Array{Any}(len)
+
+    # Are we directly constructing the type, if so all values must be
+    # supplied by the caller, we use this state to ensure this
+    construct = false
+    # handle the case where this is defining a datatype
+    for i in 1:len
+        expr = exprs[i]
+        ( sym, typ, val ) = trans( expr )
+        if( construct == true && val == nothing || ( i > 1 && construct == false && val != nothing ))
+            error( "Invalid tuple, all values must be specified during construction @ ($expr)")
+        end
+        construct = val !== nothing
+        fields[i] = QuoteNode(sym !== nothing ? sym : Symbol("_$(i)_"))
+        typs[i] = typ !== nothing ? typ : :Any
+        # On construction ensure that the types are consitent with the declared types, if applicable
+        values[i] = (typ !== nothing && construct) ? Expr( :call, :convert, typ, val ) : val
+    end
+
+    ex = if construct
+        :(NamedTuples.NT([$(fields...)], Any[$(values...)]))
+    elseif len > 0 && !isa(exprs, Tuple{Vararg{Symbol}})
+        :(NamedTuples.NT([$(fields...)], Type[$(typs...)]))
+    else
+        :(NamedTuples.NT([$(fields...)]))
+    end
+
+    return esc(ex)
 end
+
+function NT(names::AbstractVector{Symbol}, values::AbstractVector)
+    T = NT(names)
+    T(values...)
+end
+
+function NT(names::AbstractVector{Symbol}, types::AbstractVector{<:Type})
+    T = NT(names)
+    T{types...}
+end
+
+function NT(names::AbstractVector{Symbol})
+    create_namedtuple_type(names)
+end
+
 
 # Helper function for 0.4 compat
 if VERSION < v"0.5.0"

--- a/test/IncrementalCompilation/src/IncrementalCompilation.jl
+++ b/test/IncrementalCompilation/src/IncrementalCompilation.jl
@@ -1,0 +1,10 @@
+__precompile__()
+module IncrementalPrecompilation
+
+using NamedTuples
+
+function demo()
+    @NT(cols=5)
+end
+
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+Suppressor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using NamedTuples
+using Suppressor
 using Base.Test
 
 @test @NT( a = 1 ).a == 1
@@ -106,3 +107,10 @@ module B
 end
 
 @test A.NT === B.NT
+
+# Test incremental compilation
+push!(LOAD_PATH, @__DIR__)
+output = @capture_err begin
+    Base.compilecache("IncrementalCompilation")
+end
+@test output == ""  # Shows output better than using `isempty`


### PR DESCRIPTION
The DataStreams package was running into issues with incremental pre-compilation with the NamedTuples package:

```julia
julia> Base.compilecache("DataStreams")
INFO: Recompiling stale cache file /Users/omus/.julia/lib/v0.6/DataStreams.ji for module DataStreams.
WARNING: eval from module NamedTuples to Data:
Expr(:type, false, Expr(:<:, Expr(:curly, :_NT_col, :T1)::Any, NamedTuples.NamedTuple)::Any, Expr(:block, Expr(:::, :col, :T1)::Any, Expr(:tuple)::Any)::Any)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module NamedTuples to Data:
Expr(:type, false, Expr(:<:, Expr(:curly, :_NT_name_compute_computeargs, :T1, :T2, :T3)::Any, NamedTuples.NamedTuple)::Any, Expr(:block, Expr(:::, :name, :T1)::Any, Expr(:::, :compute, :T2)::Any, Expr(:::, :computeargs, :T3)::Any, Expr(:tuple)::Any)::Any)::Any
  ** incremental compilation may be broken for this module **
```

These warnings occurred because the current implementation of `@NT` performs an `eval` during macro expansion. In this PR the `@NT` macro has been revised to only perform the `eval` at runtime which makes incremental compilation work. To do this I needed to break apart the `make_tuple` function into two parts: initial expression parsing and type creation later. In order to make this change completely non-breaking I have left `make_tuple` as is and placed the initial expression parsing components directly in the `@NT` macro and have put the runtime type creation part of the `NT` function.

These changes should properly address the change that @quinnj wanted as part of https://github.com/JuliaData/NamedTuples.jl/pull/46 without generating duplicate types and should allow the DataStreams package to no longer require a custom fork of NamedTuples.jl