### PR TITLE
End of life package more gracefully.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaData/NamedTuples.jl?svg=true)](https://ci.appveyor.com/project/quinnj/namedtuples-jl)
 [![codecov.io](http://codecov.io/github/JuliaData/NamedTuples.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaData/NamedTuples.jl?branch=master)
 
+# Important Notice
+
+This package is discontinued starting from Julia 0.7, since named
+tuples are now part of base Julia. Any use of the `@NT` macro will result
+in an error.
+
+The package can still be used on Julia 0.6 but will not be developed
+further.
+
 # NamedTuples
 
 NamedTuples.jl provides a high performance implementation of named tuples for Julia (cf named tuples in python). Julia tuples are restricted to supporting index based access. This new implementation allows both index and property based access. NamedTuples may be used anywhere that a tuple is currently being used, for example in the definition of a method or as the return value of a method. NamedTuples are implemented using Julia’s macro system, ensuring that the run time cost is equivalent to constructing a regular immutable type.


### PR DESCRIPTION
The current situation with NamedTuples uninstallable on Julia 0.7 and 1.0, while still a dependency of other packages and/or already installed by users is not satisfactory. See e.g.
* https://discourse.julialang.org/t/cant-add-juliadb/14616/5
* https://discourse.julialang.org/t/package-restricted-to-versions/14539/4
* https://discourse.julialang.org/t/namedtuples-and-dependent-packages/14493/4

This PR, after having been tagged and accepted in METADATA, moves the point of failure to use of the package instead of installation, and gives a helpful error message as well as explaining the situation in the README.
```
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.0.0 (2018-08-08)
 _/ |\__'_|_|_|\__'_|  |  
|__/                   |

julia> using NamedTuples

julia> @NT(a=1)
ERROR: The NamedTuples package has been discontinued starting from Julia 0.7. Use the named tuples included in base Julia instead.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at none:0
```